### PR TITLE
Support micropython 1.19+

### DIFF
--- a/moduqr.c
+++ b/moduqr.c
@@ -331,7 +331,11 @@ const mp_obj_module_t mp_module_uqr = {
 };
 #endif
 
+#if MICROPY_VERSION >= 0x011300
+MP_REGISTER_MODULE(MP_QSTR_uqr, mp_module_uqr);
+#else
 MP_REGISTER_MODULE(MP_QSTR_uqr, mp_module_uqr, 1);
+#endif
 
 // Linking glue for dyno-loaded module
 #if MICROPY_ENABLE_DYNRUNTIME


### PR DESCRIPTION
viz subject. uPy 1.19+ changed MP_REGISTER_MODULE, so added support for this version.

Tested - works OK